### PR TITLE
Make mermaid plots prettier

### DIFF
--- a/src/mermaid.jl
+++ b/src/mermaid.jl
@@ -108,7 +108,6 @@ function _mermaid_subgraph_from_dag_step(step::DAGStep)
     # Helper function that adds a "specification" box (graph node), which lists the internal
     # fields of the specification
     _schema_subgraph = (fieldmap::Dict, prefix) -> begin
-        # @info "okay"
         content = map(collect(keys(fieldmap))) do fieldname
             type = fieldmap[fieldname]
             node_name = _field_node_name(fieldname, prefix, node_key)
@@ -125,7 +124,6 @@ function _mermaid_subgraph_from_dag_step(step::DAGStep)
             return [node_contents,
                     "class $(node_name) classSpecField"]
         end
-        # @info content
         return collect(Iterators.flatten(content))
     end
 


### PR DESCRIPTION
- ...when a node is a nothrow identity transform, don't duplicate input and output, just show it once
- when a node's contents are a special-cased struct, format more concisely