### PR TITLE
make including the tests twice succeed

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -6,12 +6,10 @@ on:
   workflow_dispatch:
 jobs:
   TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'beacon-buddy'
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}
-          registry: beacon-biosignals/BeaconRegistry
-          registry_ssh: ${{ secrets.BEACON_REGISTRY_RO_SSH_KEY }}

--- a/.github/workflows/TransformSpecifications_CI.yml
+++ b/.github/workflows/TransformSpecifications_CI.yml
@@ -37,19 +37,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      # - uses: aws-actions/configure-aws-credentials@v1
-      #   with:
-      #     aws-region: us-east-2
-      #     role-to-assume: arn:aws:iam::185776040155:role/transformspecifications-ci
-      #     role-duration-seconds: 43200
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/add-julia-registry@v1
-        with:
-          key: ${{ secrets.BEACONBUDDY_SSH_KEY }}
-          registry: beacon-biosignals/BeaconRegistry
       - uses: julia-actions/cache@v1
         with:
           cache-name: "${{ github.workflow }}-${{ github.job }}-${{ matrix.runs-on }}"
@@ -64,9 +55,3 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: lcov.info
-      # - name: Percy Upload
-      #   uses: percy/exec-action@v0.3.1
-      #   with:
-      #     custom-command: "npx @percy/cli upload ./test/test_images"
-      #   env:
-      #     PERCY_TOKEN: ${{ secrets.PERCY_TRANSFORM_SPECIFICATIONS }}

--- a/.github/workflows/TransformSpecifications_docs.yml
+++ b/.github/workflows/TransformSpecifications_docs.yml
@@ -27,10 +27,6 @@ jobs:
       - uses: julia-actions/setup-julia@latest
         with:
           version: 1.8
-      - uses: julia-actions/add-julia-registry@v1
-        with:
-          key: ${{ secrets.BEACONBUDDY_SSH_KEY }}
-          registry: beacon-biosignals/BeaconRegistry
       - uses: julia-actions/cache@v1
         with:
           cache-name: "${{ github.workflow }}-${{ github.job }}-${{ matrix.runs-on }}"

--- a/test/mermaid.jl
+++ b/test/mermaid.jl
@@ -55,11 +55,16 @@ end
         function TransformSpecifications.field_dict_value(t::Type{SchemaRadV1})
             return TransformSpecifications.field_dict(t)
         end
-        test_str = ("```mermaid\n$(mermaidify(dag))\n```\n")
-        ref_test_file = joinpath(pkgdir(TransformSpecifications), "test",
-                                 "reference_tests",
-                                 "mermaid_custom.md")
-        test_equals_reference(test_str, ref_test_file)
+        try
+            test_str = ("```mermaid\n$(mermaidify(dag))\n```\n")
+            ref_test_file = joinpath(pkgdir(TransformSpecifications), "test",
+                                     "reference_tests",
+                                     "mermaid_custom.md")
+            test_equals_reference(test_str, ref_test_file)
+        finally
+            # Reset definition back to the default to ensure the tests are re-runnable
+            TransformSpecifications.field_dict_value(t::Type{SchemaRadV1}) = t
+        end
         # If this test fails because the generated output is intentionally different,
         # update the reference by doing
         # update_reference!(test_str, ref_test_file)

--- a/test/mermaid.jl
+++ b/test/mermaid.jl
@@ -55,16 +55,11 @@ end
         function TransformSpecifications.field_dict_value(t::Type{SchemaRadV1})
             return TransformSpecifications.field_dict(t)
         end
-        try
-            test_str = ("```mermaid\n$(mermaidify(dag))\n```\n")
-            ref_test_file = joinpath(pkgdir(TransformSpecifications), "test",
-                                     "reference_tests",
-                                     "mermaid_custom.md")
-            test_equals_reference(test_str, ref_test_file)
-        finally
-            # Reset definition back to the default to ensure the tests are re-runnable
-            TransformSpecifications.field_dict_value(t::Type{SchemaRadV1}) = t
-        end
+        test_str = ("```mermaid\n$(mermaidify(dag))\n```\n")
+        ref_test_file = joinpath(pkgdir(TransformSpecifications), "test",
+                                 "reference_tests",
+                                 "mermaid_custom.md")
+        test_equals_reference(test_str, ref_test_file)
         # If this test fails because the generated output is intentionally different,
         # update the reference by doing
         # update_reference!(test_str, ref_test_file)

--- a/test/nothrow_dag.jl
+++ b/test/nothrow_dag.jl
@@ -183,8 +183,14 @@ end
         # If we _want_ to be able to recurse into a specific specification type,
         # define an overloaded `field_dict_value` implementation of it:
         TransformSpecifications.field_dict_value(t::Type{SchemaFooV1}) = field_dict(t)
-        recursed = field_dict(TestTypeV1)
-        @test recursed == Dict(:schemafoo => Dict(:list => Vector{Int64}, :foo => String),
-                               :str => String)
+        try
+            recursed = field_dict(TestTypeV1)
+            @test recursed ==
+                  Dict(:schemafoo => Dict(:list => Vector{Int64}, :foo => String),
+                       :str => String)
+        finally
+            # Reset to default definition, to ensure the test is re-runnable
+            TransformSpecifications.field_dict_value(t::Type{SchemaFooV1}) = t
+        end
     end
 end

--- a/test/set_up_tests.jl
+++ b/test/set_up_tests.jl
@@ -13,11 +13,6 @@ if !isdefined(TransformSpecifications, :META) # avoids annoying warning if this 
                         :(using TransformSpecifications); recursive=true)
 end
 
-# For `test/mermaid.jl`
-module A
-struct X end
-end
-
 function test_equals_reference(test_str::String, ref_path)
     ref_str = read(ref_path, String)
     @test isequal(ref_str, test_str)


### PR DESCRIPTION
Here I've proposed some small changes to #21 to ensure the tests are re-runnable. I have found this can make a big ergonomic difference when developing a package, if the tests don't have long-lasting stateful effects.

With this,
```julia
using TestEnv
TestEnv.activate()
include("test/runtests.jl")
include("test/runtests.jl")
```
everything passes both times.